### PR TITLE
Push Authentication from Notification Fix

### DIFF
--- a/app/src/main/java/it/netknights/piauthenticator/viewcontroller/MainActivity.java
+++ b/app/src/main/java/it/netknights/piauthenticator/viewcontroller/MainActivity.java
@@ -200,7 +200,7 @@ public class MainActivity extends AppCompatActivity implements ActionMode.Callba
         String signature = intent.getStringExtra(SIGNATURE);
         String question = intent.getStringExtra(QUESTION);
         int notificationID = intent.getIntExtra(NOTIFICATION_ID, 654321);
-        boolean sslVerify = intent.getBooleanExtra(SSL_VERIFY, true);
+        boolean sslVerify = intent.getBooleanExtra(SSL_VERIFY, !intent.getStringExtra(SSL_VERIFY).equals("0"));
         if (serial != null && nonce != null && title != null && url != null && signature != null && question != null) {
             logprint("Intent data: " + intent.getExtras().toString());
             presenterInterface.addPushAuthRequest(new PushAuthRequest(nonce, url, serial, question, title, signature, notificationID, sslVerify));


### PR DESCRIPTION
Push authentication was working if app was in the foreground but not in the background.

Steps to reproduce:
1. Put app in background and start a push
2. Tap notification in notification tray
3. Application launches and displays 'Confirm' button
4. Tapping confirm causes 'Authenticating...' to spin forever

When checking the code it appears sslverify was getting set to true all the time from the notification tray but not from within the app causing a silent 'Signature invalid' error that was never displayed to the user. (PushAuthTask.java:106)

I believe the getBooleanExtra is always failing and returning the default value of true. (MainActivity.java:203).  I have added a workaround to fallback to string parsing if the boolean value retrieval fails.