### PR TITLE
Push Token Auth Error Handling

### DIFF
--- a/app/src/main/java/it/netknights/piauthenticator/presenter/Presenter.java
+++ b/app/src/main/java/it/netknights/piauthenticator/presenter/Presenter.java
@@ -79,8 +79,6 @@ import static it.netknights.piauthenticator.utils.AppConstants.STATUS_STANDARD_R
 import static it.netknights.piauthenticator.utils.AppConstants.STATUS_TWO_STEP_ROLLOUT;
 import static it.netknights.piauthenticator.utils.AppConstants.STATUS_TWO_STEP_ROLLOUT_DONE;
 import static it.netknights.piauthenticator.utils.AppConstants.TOTP;
-import static it.netknights.piauthenticator.utils.AppConstants.PA_INVALID_SIGNATURE;
-import static it.netknights.piauthenticator.utils.AppConstants.PA_SIGNING_FAILURE;
 import static it.netknights.piauthenticator.utils.OTPGenerator.generate;
 import static it.netknights.piauthenticator.utils.OTPGenerator.hashPIN;
 import static it.netknights.piauthenticator.utils.Util.logprint;

--- a/app/src/main/java/it/netknights/piauthenticator/presenter/Presenter.java
+++ b/app/src/main/java/it/netknights/piauthenticator/presenter/Presenter.java
@@ -56,6 +56,8 @@ import it.netknights.piauthenticator.utils.SecretKeyWrapper;
 import it.netknights.piauthenticator.utils.Util;
 
 import static it.netknights.piauthenticator.utils.AppConstants.HOTP;
+import static it.netknights.piauthenticator.utils.AppConstants.PA_INVALID_SIGNATURE;
+import static it.netknights.piauthenticator.utils.AppConstants.PA_SIGNING_FAILURE;
 import static it.netknights.piauthenticator.utils.AppConstants.PRO_STATUS_BAD_BASE64;
 import static it.netknights.piauthenticator.utils.AppConstants.PRO_STATUS_DONE;
 import static it.netknights.piauthenticator.utils.AppConstants.PRO_STATUS_MALFORMED_JSON;
@@ -77,6 +79,8 @@ import static it.netknights.piauthenticator.utils.AppConstants.STATUS_STANDARD_R
 import static it.netknights.piauthenticator.utils.AppConstants.STATUS_TWO_STEP_ROLLOUT;
 import static it.netknights.piauthenticator.utils.AppConstants.STATUS_TWO_STEP_ROLLOUT_DONE;
 import static it.netknights.piauthenticator.utils.AppConstants.TOTP;
+import static it.netknights.piauthenticator.utils.AppConstants.PA_INVALID_SIGNATURE;
+import static it.netknights.piauthenticator.utils.AppConstants.PA_SIGNING_FAILURE;
 import static it.netknights.piauthenticator.utils.OTPGenerator.generate;
 import static it.netknights.piauthenticator.utils.OTPGenerator.hashPIN;
 import static it.netknights.piauthenticator.utils.Util.logprint;
@@ -724,6 +728,18 @@ public class Presenter implements PresenterInterface, PresenterTaskInterface, Pr
             case STATUS_ENDPOINT_SSL_ERROR: {
                 cancelAuthentication(token);
                 mainActivityInterface.makeToast(R.string.SSLHandshakeFailed);
+                break;
+            }
+            case PA_INVALID_SIGNATURE: {
+                cancelAuthentication(token);
+                token.getPendingAuths().remove(0);
+                mainActivityInterface.makeToast(R.string.PushAuthInvalidSignature);
+                break;
+            }
+            case PA_SIGNING_FAILURE: {
+                cancelAuthentication(token);
+                token.getPendingAuths().remove(0);
+                mainActivityInterface.makeToast(R.string.PushAuthSigningError);
                 break;
             }
             default:

--- a/app/src/main/java/it/netknights/piauthenticator/services/FCMReceiverService.java
+++ b/app/src/main/java/it/netknights/piauthenticator/services/FCMReceiverService.java
@@ -177,7 +177,8 @@ public class FCMReceiverService extends FirebaseMessagingService {
                 .addAction(action)                                     // Add the allow Button
                 .setAutoCancel(true)                                   // Remove the notification after tabbing it
                 .setWhen(0)
-                .setContentIntent(pActivity_intent);                   // Intent for opening activity with the request
+                .setContentIntent(pActivity_intent)                    // Intent for opening activity with the request
+                .setDefaults(Notification.DEFAULT_SOUND);              // Play a sound/vibrate for push auth
 
         if (subText != null) {
             mBuilder.setSubText(subText);

--- a/app/src/main/java/it/netknights/piauthenticator/tasks/PushAuthTask.java
+++ b/app/src/main/java/it/netknights/piauthenticator/tasks/PushAuthTask.java
@@ -144,8 +144,12 @@ public class PushAuthTask extends AsyncTask<Void, Integer, Boolean> implements E
         int code = values[0];
         switch (code) {
             case PA_INVALID_SIGNATURE:
+                logprint("authentication failed due to invalid signature :(");
+                pushAuthCallbackInterface.handleError(code, token);
                 break;
             case PA_SIGNING_FAILURE:
+                logprint("authentication failed due to signing failure :(");
+                pushAuthCallbackInterface.handleError(code, token);
                 break;
             case PA_AUTHENTICATION_FINISHED:
                 if (success) {

--- a/app/src/main/java/it/netknights/piauthenticator/viewcontroller/MainActivity.java
+++ b/app/src/main/java/it/netknights/piauthenticator/viewcontroller/MainActivity.java
@@ -200,7 +200,7 @@ public class MainActivity extends AppCompatActivity implements ActionMode.Callba
         String signature = intent.getStringExtra(SIGNATURE);
         String question = intent.getStringExtra(QUESTION);
         int notificationID = intent.getIntExtra(NOTIFICATION_ID, 654321);
-        boolean sslVerify = intent.getBooleanExtra(SSL_VERIFY, !intent.getStringExtra(SSL_VERIFY).equals("0"));
+        boolean sslVerify = intent.getBooleanExtra(SSL_VERIFY, !"0".equals(intent.getStringExtra(SSL_VERIFY)));
         if (serial != null && nonce != null && title != null && url != null && signature != null && question != null) {
             logprint("Intent data: " + intent.getExtras().toString());
             presenterInterface.addPushAuthRequest(new PushAuthRequest(nonce, url, serial, question, title, signature, notificationID, sslVerify));

--- a/app/src/main/java/it/netknights/piauthenticator/viewcontroller/MainActivity.java
+++ b/app/src/main/java/it/netknights/piauthenticator/viewcontroller/MainActivity.java
@@ -200,7 +200,7 @@ public class MainActivity extends AppCompatActivity implements ActionMode.Callba
         String signature = intent.getStringExtra(SIGNATURE);
         String question = intent.getStringExtra(QUESTION);
         int notificationID = intent.getIntExtra(NOTIFICATION_ID, 654321);
-        boolean sslVerify = intent.getBooleanExtra(SSL_VERIFY, true);
+        boolean sslVerify = intent.getBooleanExtra(SSL_VERIFY, !intent.getStringExtra(SSL_VERIFY).equals("0"));
         if (serial != null && nonce != null && title != null && url != null && signature != null && question != null) {
             logprint("Intent data: " + intent.getExtras().toString());
             presenterInterface.addPushAuthRequest(new PushAuthRequest(nonce, url, serial, question, title, signature, notificationID, sslVerify));

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -91,4 +91,6 @@
     <string name="device_not_supported_text">Dieses Android-Gerät unterstützt die sichere Speicherung von Tokens nicht, daher kann die Anwendung nicht verwendet werden.</string>
     <string name="firebase_config_broken_title">Firebase falsch konfiguriert</string>
     <string name="firebase_config_broken">Firebase scheint falsch konfiguriert zu sein, bitte informieren sie den zuständigen Administrator darüber.</string>
+    <string name="PushAuthInvalidSignature">Die Authentifizierungssignatur ist ungültig. Versuchen Sie erneut, sich zu authentifizieren.</string>
+    <string name="PushAuthSigningError">Authentifizierung konnte nicht signiert werden. Versuchen Sie, ein neues Token zu registrieren.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,5 +123,7 @@
     <string name="NotificationWithToken">With token</string>
     <string name="ERR_SERVER_UNREACHABLE">Server was unreachable.</string>
     <string name="retry_authentication">Retry Authentication</string>
+    <string name="PushAuthInvalidSignature">Authentication signature is invalid. Try to authenticate again.</string>
+    <string name="PushAuthSigningError">Authentication could not be signed. Try enrolling a new token.</string>
 
 </resources>


### PR DESCRIPTION
Properly cancels/removes authentications that fail signature verfication or signing as they are unrecoverable.

Resolves issue with sslVerify being set to false and push notification being tapped from notification center defaulting to true.