### PR TITLE
push improvement, layout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
 
         def versionMajor = 2
         def versionMinor = 0
-        def versionPatch = 1
+        def versionPatch = 2
         def versionAdditive = ""
 
         versionCode versionMajor * 10000 + versionMinor * 100 + versionPatch

--- a/app/src/androidTest/java/it/netknights/piauthenticator/DetailAndMenuTest.java
+++ b/app/src/androidTest/java/it/netknights/piauthenticator/DetailAndMenuTest.java
@@ -440,7 +440,7 @@ public class DetailAndMenuTest {
         textView13.check(matches(withText("Nam")));
 
         ViewInteraction button4 = onView(
-                allOf(withId(R.id.next_button),
+                allOf(withId(R.id.allow_button),
                         isDisplayed()));
         button4.check(matches(isDisplayed()));
 
@@ -757,17 +757,17 @@ public class DetailAndMenuTest {
     public void testNextButtonDelay() {
         setupForNextButton();
 
-        onView(allOf(withId(R.id.next_button), withText(R.string.button_text_next))).perform(click());
+        onView(allOf(withId(R.id.allow_button), withText(R.string.button_text_next))).perform(click());
 
         // next 963 548
         onView(allOf(withId(R.id.textViewToken), withText("963 548"))).check(matches(withText("963 548")));
-        onView(allOf(withId(R.id.next_button), withText(R.string.button_text_next))).perform(click());
+        onView(allOf(withId(R.id.allow_button), withText(R.string.button_text_next))).perform(click());
 
         // check that the click was not performed
         onView(allOf(withId(R.id.textViewToken), withText("963 548"))).check(matches(withText("963 548")));
 
         sleep();
-        onView(allOf(withId(R.id.next_button), withText(R.string.button_text_next))).perform(click());
+        onView(allOf(withId(R.id.allow_button), withText(R.string.button_text_next))).perform(click());
         onView(allOf(withId(R.id.textViewToken), withText("364 247"))).check(matches(withText("364 247")));
     }
 

--- a/app/src/androidTest/java/it/netknights/piauthenticator/NormalToken.java
+++ b/app/src/androidTest/java/it/netknights/piauthenticator/NormalToken.java
@@ -118,7 +118,7 @@ public class NormalToken {
                 .check(matches(withText(startsWith("163 584"))));
 
         // Check that the next button is displayed and the progressbar is not
-        onView(withId(R.id.next_button)).check(matches(allOf(isDisplayed(), withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))));
+        onView(withId(R.id.allow_button)).check(matches(allOf(isDisplayed(), withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))));
         onView(withId(R.id.progressBar)).check(matches(allOf(not(isDisplayed()), withEffectiveVisibility(GONE))));
     }
 
@@ -159,7 +159,7 @@ public class NormalToken {
                         withAnyString()))); // The OTP is not the same even though the secret is the same
         // Check that the progressbar is displayed and the next button not
         onView(withId(R.id.progressBar)).check(matches(allOf(isDisplayed(), withEffectiveVisibility(VISIBLE))));
-        onView(withId(R.id.next_button)).check(matches(allOf(not(isDisplayed()), withEffectiveVisibility(GONE))));
+        onView(withId(R.id.allow_button)).check(matches(allOf(not(isDisplayed()), withEffectiveVisibility(GONE))));
     }
 
     @Test
@@ -225,7 +225,7 @@ public class NormalToken {
                         withAnyString())));
         // Check that the progressbar is displayed and the next button is not
         onView(withId(R.id.progressBar)).check(matches(allOf(isDisplayed(), withEffectiveVisibility(VISIBLE))));
-        onView(withId(R.id.next_button)).check(matches(allOf(not(isDisplayed()), withEffectiveVisibility(GONE))));
+        onView(withId(R.id.allow_button)).check(matches(allOf(not(isDisplayed()), withEffectiveVisibility(GONE))));
 
     }
 

--- a/app/src/androidTest/java/it/netknights/piauthenticator/PushRolloutAuth.java
+++ b/app/src/androidTest/java/it/netknights/piauthenticator/PushRolloutAuth.java
@@ -157,16 +157,16 @@ public class PushRolloutAuth {
         onView(withId(R.id.textViewToken)).check(matches(withText("privacyIDEA: PIPU0001D07B")));
         onView(withId(R.id.textViewLabel)).check(matches(withText((R.string.PushtokenLabelRolloutUnfinished))));
         // the button is visible to retry the rollout
-        onView(withId(R.id.next_button)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
+        onView(withId(R.id.allow_button)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 
         // Press the retry button
-        onView(withId(R.id.next_button)).perform(click());
+        onView(withId(R.id.allow_button)).perform(click());
         //sleep(5000);
 
         // Validate token rolled out now
         onView(withId(R.id.textViewToken)).check(matches(withText("privacyIDEA: PIPU0001D07B")));
         onView(withId(R.id.textViewLabel)).check(matches(withText((R.string.PushtokenLabel))));
-        onView(withId(R.id.next_button)).check(matches(withEffectiveVisibility(GONE)));
+        onView(withId(R.id.allow_button)).check(matches(withEffectiveVisibility(GONE)));
 
         // Restart the App with an intent containing the PushAuthRequest(data)
         String title = "titletitle";
@@ -193,7 +193,7 @@ public class PushRolloutAuth {
         onView(withId(R.id.textViewToken)).check(matches(withText("privacyIDEA: PIPU0001D07B")));
         onView(withId(R.id.textViewLabel)).check(matches(withText(title)));
         onView(withId(R.id.textView_pushStatus)).check(matches(withText(question)));
-        onView(withId(R.id.next_button)).check(matches(allOf(withEffectiveVisibility(VISIBLE),
+        onView(withId(R.id.allow_button)).check(matches(allOf(withEffectiveVisibility(VISIBLE),
                 withText(R.string.Allow))));
 
 
@@ -204,7 +204,7 @@ public class PushRolloutAuth {
                         " {\"status\": true, \"value\": true}, \"time\": 1554457850.641362, \"id\": 1}"));
 
         // Click allow
-        onView(withId(R.id.next_button)).perform(click());
+        onView(withId(R.id.allow_button)).perform(click());
 
         // Toast is displayed indicating success
 //        onView(withText(R.string.AuthenticationSuccessful)).check(matches(isDisplayed()));
@@ -212,7 +212,7 @@ public class PushRolloutAuth {
         // Row in list is back to normal
         onView(withId(R.id.textViewToken)).check(matches(withText("privacyIDEA: PIPU0001D07B")));
         onView(withId(R.id.textViewLabel)).check(matches(withText((R.string.PushtokenLabel))));
-        onView(withId(R.id.next_button)).check(matches(withEffectiveVisibility(GONE)));
+        onView(withId(R.id.allow_button)).check(matches(withEffectiveVisibility(GONE)));
     }
 
     @After

--- a/app/src/main/java/it/netknights/piauthenticator/interfaces/PresenterInterface.java
+++ b/app/src/main/java/it/netknights/piauthenticator/interfaces/PresenterInterface.java
@@ -76,6 +76,8 @@ public interface PresenterInterface {
 
     void removeCurrentSelection();
 
+    void removeCurrentAuthRequest(Token token);
+
     String getCurrentSelectionLabel();
 
     String getCurrentSelectionOTP();

--- a/app/src/main/java/it/netknights/piauthenticator/model/Token.java
+++ b/app/src/main/java/it/netknights/piauthenticator/model/Token.java
@@ -50,6 +50,7 @@ public class Token {
     public Date rollout_expiration;
     public String rollout_url;
     public boolean sslVerify = true;
+    public boolean lastAuthHadError = false;
 
     private ArrayList<PushAuthRequest> pendingAuths = new ArrayList<>();
     public State state = UNFINISHED;

--- a/app/src/main/java/it/netknights/piauthenticator/presenter/Presenter.java
+++ b/app/src/main/java/it/netknights/piauthenticator/presenter/Presenter.java
@@ -294,6 +294,14 @@ public class Presenter implements PresenterInterface, PresenterTaskInterface, Pr
     }
 
     @Override
+    public void removeCurrentAuthRequest(Token token) {
+        PushAuthRequest req = token.getPendingAuths().remove(0);
+        mainActivityInterface.cancelNotification(req.getNotificationID());
+        tokenListInterface.notifyChange();
+        token.lastAuthHadError = false;
+    }
+
+    @Override
     public String getCurrentSelectionLabel() {
         if (model.getCurrentSelection() == null) return null;
         return model.getCurrentSelection().getLabel();
@@ -719,6 +727,7 @@ public class Presenter implements PresenterInterface, PresenterTaskInterface, Pr
 
     @Override
     public void handleError(int statusCode, Token token) {
+        token.lastAuthHadError = true;
         switch (statusCode) {
             case STATUS_ENDPOINT_UNKNOWN_HOST: {
                 // Network unreachable

--- a/app/src/main/java/it/netknights/piauthenticator/utils/Util.java
+++ b/app/src/main/java/it/netknights/piauthenticator/utils/Util.java
@@ -134,6 +134,7 @@ public class Util {
      * @return An ArrayList of Tokens
      */
     public ArrayList<Token> loadTokens() {
+        logprint("LOADING TOKEN");
         ArrayList<Token> tokens = new ArrayList<>();
         try {
             byte[] data = loadDataFromFile(DATAFILE);
@@ -157,10 +158,10 @@ public class Util {
      * @param tokens ArrayList of tokens to save
      */
     public void saveTokens(ArrayList<Token> tokens) {
-        JSONArray tmp = new JSONArray();
         if (tokens == null) {
             return;
         }
+        JSONArray tmp = new JSONArray();
         for (Token t : tokens) {
             try {
                 tmp.put(makeJSONfromToken(t));
@@ -439,7 +440,7 @@ public class Util {
             String api_key = o.getString(API_KEY);
             String projNumber = o.getString(PROJECT_NUMBER);
 
-            logprint("Firebase config loaded.");
+            //logprint("Firebase config loaded.");
             return new FirebaseInitConfig(projID, appID, api_key, projNumber);
 
         } catch (Exception e) {

--- a/app/src/main/java/it/netknights/piauthenticator/viewcontroller/MainActivity.java
+++ b/app/src/main/java/it/netknights/piauthenticator/viewcontroller/MainActivity.java
@@ -259,15 +259,18 @@ public class MainActivity extends AppCompatActivity implements ActionMode.Callba
         // this is the item selected from the toolbar menu
         int id = item.getItemId();
         // save the tokenlist before another activity starts it's lifecycle
-        presenterInterface.saveTokenlist();
+        //presenterInterface.saveTokenlist();
         if (id == R.id.action_about) {
+            unregisterReceiver(receiver);
             Intent aboutintent = new Intent(this, AboutActivity.class);
             startActivity(aboutintent);
             return true;
         }
         if (id == R.id.action_enter_detail) {
+            unregisterReceiver(receiver);
             Intent enterDetailIntent = EnterDetailsActivity.makeIntent(MainActivity.this);
             startActivityForResult(enterDetailIntent, INTENT_ADD_TOKEN_MANUALLY);
+            return true;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/res/layout/entry_normal.xml
+++ b/app/src/main/res/layout/entry_normal.xml
@@ -59,7 +59,7 @@
         app:autoSizeTextType="uniform" />
 
     <Button
-        android:id="@+id/next_button"
+        android:id="@+id/allow_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignTop="@+id/textViewToken"

--- a/app/src/main/res/layout/entry_push.xml
+++ b/app/src/main/res/layout/entry_push.xml
@@ -43,51 +43,71 @@
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform" />
 
-    <Button
-        android:id="@+id/next_button"
-        android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/textViewLabel"
-        android:layout_alignParentEnd="true"
-        android:layout_marginTop="14dp"
-        android:layout_marginEnd="8dp"
-        android:backgroundTint="@color/PIBLUE"
-        android:text="@string/Allow"
-        android:textColor="@color/zxing_status_text" />
-
-    <TextView
-        android:id="@+id/textView_pushStatus"
-        android:layout_width="wrap_content"
-        android:layout_height="44dp"
-        android:layout_below="@+id/textViewLabel"
         android:layout_alignParentStart="true"
-        android:layout_marginStart="64dp"
-        android:layout_marginTop="18dp"
-        android:layout_marginEnd="3dp"
-        android:layout_toStartOf="@+id/next_button"
-        android:text="@string/PushtokenRollingOut"
-        android:textAlignment="center"
-        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
-
-    <ProgressBar
-        android:id="@+id/progressBar_push"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/textViewLabel"
         android:layout_alignParentEnd="true"
         android:layout_marginStart="8dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:indeterminate="true" />
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp">
 
-    <ImageView
-        android:id="@+id/imageView_cancel"
-        android:layout_width="54dp"
-        android:layout_height="49dp"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="98dp"
-        app:srcCompat="@drawable/ic_cancel_blue" />
+        <TextView
+            android:id="@+id/textView_pushStatus"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/PushtokenRollingOut"
+            android:textAlignment="center"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/dismiss_button"
+            app:layout_constraintStart_toEndOf="@+id/imageView_cancel"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/imageView_cancel"
+            android:layout_width="31dp"
+            android:layout_height="44dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/textView_pushStatus"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_cancel_blue" />
+
+        <ProgressBar
+            android:id="@+id/progressBar_push"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/allow_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/PIBLUE"
+            android:text="@string/Allow"
+            android:textColor="@color/zxing_status_text"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/dismiss_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:backgroundTint="@color/PIBLUE"
+            android:text="@string/Dismiss"
+            android:textColor="@color/zxing_status_text"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/allow_button"
+            app:layout_constraintStart_toEndOf="@+id/textView_pushStatus"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -93,4 +93,5 @@
     <string name="firebase_config_broken">Firebase scheint falsch konfiguriert zu sein, bitte informieren sie den zuständigen Administrator darüber.</string>
     <string name="PushAuthInvalidSignature">Die Authentifizierungssignatur ist ungültig. Versuchen Sie erneut, sich zu authentifizieren.</string>
     <string name="PushAuthSigningError">Authentifizierung konnte nicht signiert werden. Versuchen Sie, ein neues Token zu registrieren.</string>
+    <string name="Dismiss">Verwerfen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,5 +125,6 @@
     <string name="retry_authentication">Retry Authentication</string>
     <string name="PushAuthInvalidSignature">Authentication signature is invalid. Try to authenticate again.</string>
     <string name="PushAuthSigningError">Authentication could not be signed. Try enrolling a new token.</string>
+    <string name="Dismiss">Dismiss</string>
 
 </resources>


### PR DESCRIPTION
* display push auth when app is in background or closed and then put to foreground/started (closes #80)
* put UI elements for push auth request in layout to align properly
* display "dismiss" button after authentication has failed for the first time